### PR TITLE
fixed card length lookup

### DIFF
--- a/lib/card_number.dart
+++ b/lib/card_number.dart
@@ -66,7 +66,7 @@ const int DEFAULT_MAX_CARD_NUM_LENGTH = 19;
     // Check Luhn validity of the number
     isLuhnValid = checkLuhnValidity(trimmedNumStr);
 
-    int maxCardLength = ccNumLengths[type].reduce(max);
+    int maxCardLength = ccNumLengths.containsKey(type) ? ccNumLengths[type].reduce(max) : DEFAULT_MAX_CARD_NUM_LENGTH;
 
     // Check if the card number length is viable.
     // If it is then decide the potential validity of this card number


### PR DESCRIPTION
Fixed NoSuchMethodError exception when card number length lookup is performed with a card type that has no defined lengths in lookup table.