### PR TITLE
Don't print to terminal

### DIFF
--- a/lib/expiration_date.dart
+++ b/lib/expiration_date.dart
@@ -201,7 +201,6 @@ List<String> _parseDate(String expDateStr) {
 
   Match? match = expDateFormat.firstMatch(formattedStr);
   if (match != null) {
-    // print("matched! ${match[0]}");
     return match[0]!.split('/');
   } else {
     return [];

--- a/lib/expiration_date.dart
+++ b/lib/expiration_date.dart
@@ -201,12 +201,9 @@ List<String> _parseDate(String expDateStr) {
 
   Match? match = expDateFormat.firstMatch(formattedStr);
   if (match != null) {
-    print("matched! ${match[0]}");
+    // print("matched! ${match[0]}");
+    return match[0]!.split('/');
   } else {
     return [];
   }
-
-  List<String> monthAndYear = match[0]!.split('/');
-
-  return monthAndYear;
 }


### PR DESCRIPTION
Printing directly to the terminal potentially clutters the end user's output, and there's no way to turn it off / filter it out. If you still need to print something, consider implementing a flag (that defaults to off) that can be enabled when needed. Or, alternatively, using a logging package with configurable log levels (such as https://pub.dev/packages/logging)